### PR TITLE
initial import of sum squares program

### DIFF
--- a/extra/fortran/interoperability/sum-squares/Makefile
+++ b/extra/fortran/interoperability/sum-squares/Makefile
@@ -1,0 +1,31 @@
+#!/usr/bin/make
+#
+# source: Makefile
+# author: misael-diaz
+# date:   2021/05/03
+#
+# Synopsis:
+# Defines the Makefile for building the program with GNU make.
+#
+# Copyright (c) 2021 Misael Diaz-Maldonado
+#
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+include make-inc
+
+all: $(EXEC)
+
+$(EXEC): $(OBJECTS)
+	$(CXX) $(CXXOPT) $(OBJECTS) -o $(EXEC) $(LIBS)
+
+$(SUB_O): $(HEADER) $(SUB)
+	$(FC) $(FCOPT) -c $(SUB) -o $(SUB_O)
+
+$(MAIN_O): $(HEADER) $(SUB_O) $(MAIN)
+	$(CXX) $(CXXOPT) -c $(MAIN) -o $(MAIN_O)
+
+clean:
+	rm -f $(OBJECTS) $(EXEC)

--- a/extra/fortran/interoperability/sum-squares/macros.h
+++ b/extra/fortran/interoperability/sum-squares/macros.h
@@ -1,0 +1,26 @@
+#ifndef GUARD_MD_MACROS_H
+#define GUARD_MD_MACROS_H
+#define N 16
+#endif
+
+/*
+ * source: macros.cpp
+ * author: misael-diaz
+ * date:   2021/05/03
+ *
+ * Synopsis:
+ * Defines the vector size.
+ *
+ * References:
+ * A. Koenig and B. Moo, Accelerated C++ Practical Programming by Example
+ *
+ *
+ * Copyright (c) 2021 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ *
+ */
+

--- a/extra/fortran/interoperability/sum-squares/main.cpp
+++ b/extra/fortran/interoperability/sum-squares/main.cpp
@@ -1,0 +1,46 @@
+/*
+ * source: main.cpp
+ * author: misael-diaz
+ * date:   2021/05/03
+ *
+ * Synopsis:
+ * Computes the sum of the squares of a vector using standard library
+ * facilities and a Fortran subroutine.
+ *
+ * References:
+ * A. Koenig and B. Moo, Accelerated C++ Practical Programming by Example
+ * S. J. Chapman, Fortran for Scientists and Engineers
+ *
+ * Copyright (c) 2021 Misael Diaz-Maldonado
+ *
+ * This file is released under the GNU General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ */
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <vector>
+#include "macros.h"
+
+extern"C" void sum_squares(double*, double*) ;
+
+int main() {
+
+	std::vector<double> x(N), squares(N) ;
+	std::iota(x.begin(), x.end(), 0) ;
+	auto square = [](double value) { return (value * value) ; }  ;
+	std::transform(x.begin(), x.end(), squares.begin(), square) ;
+
+	double sum = 0 ;
+	sum = std::accumulate(squares.begin(), squares.end(), sum) ;
+
+	double total ;
+	sum_squares(&x[0], &total) ;
+	std::cout << "sum:   " << sum   << std::endl ;
+	std::cout << "total: " << total << std::endl ;
+
+	return 0 ;
+}

--- a/extra/fortran/interoperability/sum-squares/make-inc
+++ b/extra/fortran/interoperability/sum-squares/make-inc
@@ -1,0 +1,40 @@
+#
+# source: make-inc
+# author: misael-diaz
+# date:   2021/05/03
+#
+# Synopsis:
+# Defines the include file for building the program with GNU make.
+#
+# Copyright (c) 2021 Misael Diaz-Maldonado
+#
+# This file is released under the GNU General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+
+# compilers
+FC      = gfortran-10
+CXX     = g++-10
+
+# options
+FCOPT   = -cpp
+CXXOPT  = -std=c++20
+
+# libraries
+LIBS    = -lgfortran
+
+# headers
+HEADER  = macros.h
+
+# sources
+SUB     = sub.for
+MAIN    = main.cpp
+
+# objects
+SUB_O   = sub.o
+MAIN_O  = main.o
+OBJECTS = $(SUB_O) $(MAIN_O)
+
+# executables
+EXEC    = sum-squares

--- a/extra/fortran/interoperability/sum-squares/sub.for
+++ b/extra/fortran/interoperability/sum-squares/sub.for
@@ -1,0 +1,30 @@
+#include "macros.h"
+        !
+        ! source: sub.f90
+        ! author: misael-diaz
+        ! date:   2021/05/03
+        !
+        ! Synopsis:
+        ! Returns the sum of the squares of the elements of an array.
+        !
+        !
+        ! Copyright (c) 2021 Misael Diaz-Maldonado
+        !
+        ! This file is released under the GNU General Public License as
+        ! published by the Free Software Foundation, either version 3 of
+        ! the License, or (at your option) any later version.
+        !
+        !
+        ! References:
+        ! SJ Chapman, Fortran for scientists and engineers, 4th edition
+        !
+
+        pure subroutine sum_squares(x, total) bind(c)
+                use, intrinsic :: iso_c_binding
+                implicit none
+                real(kind=c_double), intent(in) :: x(N)
+                real(kind=c_double), intent(out) :: total
+
+                total = sum(x**2)
+        end subroutine
+


### PR DESCRIPTION
program computes the sum of the squares of a vector using standard library facilities and also with a Fortran subroutine. Size of the underlying array (of the vector) is not passed as an argument to the subroutine but instead it is defined in a header file.